### PR TITLE
Allow spaces in input files

### DIFF
--- a/src/aubio/aubio.go
+++ b/src/aubio/aubio.go
@@ -13,9 +13,9 @@ import (
 
 // SplitOnSilence splits any audio file based on its silence
 func SplitOnSilence(fname string, silenceDB int, silenceMinimumSeconds float64, correction float64) (segments []models.AudioSegment, err error) {
-	cmd := fmt.Sprintf("-s -30 %s", fname)
+	cmd := []string{"-s", "-30", fname}
 	logger.Debug(cmd)
-	out, err := exec.Command("aubioonset", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("aubioonset", cmd...).CombinedOutput()
 	if err != nil {
 		return
 	}

--- a/src/download/download.go
+++ b/src/download/download.go
@@ -87,11 +87,9 @@ func download(u string, fname string, byteLimit int64) (alternativeName string, 
 }
 
 func Youtube(u string, fname string) (alternativeName string, err error) {
-	cmd := fmt.Sprintf("--extract-audio --audio-format mp3 %s",
-		u,
-	)
+	cmd := []string{"--extract-audio", "--audio-format", "mp3", u}
 	logger.Debug(cmd)
-	out, err := exec.Command("youtube-dl", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("youtube-dl", cmd...).CombinedOutput()
 	if err != nil {
 		logger.Errorf("youtube-dl: %s", out)
 		return

--- a/src/ffmpeg/ffmpeg.go
+++ b/src/ffmpeg/ffmpeg.go
@@ -77,7 +77,8 @@ func Concatenate(fnames []string) (fname2 string, err error) {
 
 func ToMono(fname string) (fname2 string, err error) {
 	_, fname2 = filepath.Split(fname)
-	fname2 = fname2 + ".mono.wav"
+	// Create safe filenames to make ffmpeg concat happy
+	fname2 = strings.ReplaceAll(fname2, " ", "-") + ".mono.wav"
 	cmd := []string{"-y", "-i", fname, "-ss", "0", "-to", "12", "-ar", "44100", "-ac", "1", fname2}
 	logger.Debug(cmd)
 	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()

--- a/src/ffmpeg/ffmpeg.go
+++ b/src/ffmpeg/ffmpeg.go
@@ -19,9 +19,9 @@ import (
 
 // IsInstalled checks whether ffmpeg is installed
 func IsInstalled() bool {
-	cmd := fmt.Sprintf("--help")
+	cmd := []string{"--help"}
 	logger.Debug(cmd)
-	_, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	_, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		return false
 	}
@@ -62,12 +62,9 @@ func Concatenate(fnames []string) (fname2 string, err error) {
 	f.Close()
 	_, fname2 = filepath.Split(fnames[0])
 	fname2 = fname2 + "concat.wav"
-	cmd := fmt.Sprintf("-y -f concat -i %s %s",
-		f.Name(),
-		fname2,
-	)
+	cmd := []string{"-y", "-f", "concat", "-i", f.Name(), fname2}
 	logger.Debug(cmd)
-	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		logger.Errorf("ffmpeg: %s", out)
 		return
@@ -81,12 +78,9 @@ func Concatenate(fnames []string) (fname2 string, err error) {
 func ToMono(fname string) (fname2 string, err error) {
 	_, fname2 = filepath.Split(fname)
 	fname2 = fname2 + ".mono.wav"
-	cmd := fmt.Sprintf("-y -i %s -ss 0 -to 12 -ar 44100 -ac 1 %s",
-		fname,
-		fname2,
-	)
+	cmd := []string{"-y", "-i", fname, "-ss", "0", "-to", "12", "-ar", "44100", "-ac", "1", fname2}
 	logger.Debug(cmd)
-	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		logger.Errorf("ffmpeg: %s", out)
 		return
@@ -110,9 +104,9 @@ type Normalization struct {
 // Normalize will perform double pass ebu R128 normalization
 // http://peterforgacs.github.io/2018/05/20/Audio-normalization-with-ffmpeg/
 func Normalize(fname string, fnameout string) (err error) {
-	cmd := fmt.Sprintf("-i %s -af loudnorm=I=-23:LRA=7:tp=-2:print_format=json -f null -", fname)
+	cmd := []string{"-i", fname, "-af", "loudnorm=I=-23:LRA=7:tp=-2:print_format=json", "-f", "null", "-"}
 	logger.Debug(cmd)
-	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		logger.Errorf("ffmpeg: %s", out)
 		return
@@ -132,16 +126,15 @@ func Normalize(fname string, fnameout string) (err error) {
 		return
 	}
 
-	cmd = fmt.Sprintf("-i %s -ar 44100 -af loudnorm=I=-23:LRA=7:tp=-2:measured_I=%s:measured_LRA=%s:measured_tp=%s:measured_thresh=%s:offset=-0.47 -y %s",
-		fname,
-		n.InputI,
-		n.InputLra,
-		n.InputTp,
-		n.InputThresh,
-		fnameout,
-	)
+	cmd = []string{"-i", fname, "-ar", "44100", "-af",
+		fmt.Sprintf("loudnorm=I=-23:LRA=7:tp=-2:measured_I=%s:measured_LRA=%s:measured_tp=%s:measured_thresh=%s:offset=-0.47",
+			n.InputI,
+			n.InputLra,
+			n.InputTp,
+			n.InputThresh),
+		"-y", fnameout}
 	logger.Debug(cmd)
-	out, err = exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err = exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		return
 	}
@@ -153,9 +146,11 @@ func Normalize(fname string, fnameout string) (err error) {
 
 // SplitOnSilence splits any audio file based on its silence
 func SplitOnSilence(fname string, silenceDB int, silenceMinimumSeconds float64, correction float64) (segments []models.AudioSegment, err error) {
-	cmd := fmt.Sprintf("-i %s -af silencedetect=noise=%ddB:d=%2.3f -f null -", fname, silenceDB, silenceMinimumSeconds)
+	cmd := []string{"-i", fname, "-af",
+		fmt.Sprintf("silencedetect=noise=%ddB:d=%2.3f", silenceDB, silenceMinimumSeconds),
+		"-f", "null", "-"}
 	logger.Debug(cmd)
-	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		return
 	}
@@ -234,9 +229,9 @@ func SplitOnSilence(fname string, silenceDB int, silenceMinimumSeconds float64, 
 }
 
 func RemoveSilence(fnameIn, fnameOut string) (err error) {
-	cmd := fmt.Sprintf("-i %s -af silenceremove=stop_periods=-1:stop_duration=0.1:stop_threshold=-50dB -y %s", fnameIn, fnameOut)
+	cmd := []string{"-i", fnameIn, "-af", "silenceremove=stop_periods=-1:stop_duration=0.1:stop_threshold=-50dB", "-y", fnameOut}
 	logger.Debug(cmd)
-	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		return
 	}

--- a/src/ffmpeg/ffmpeg.go
+++ b/src/ffmpeg/ffmpeg.go
@@ -67,8 +67,9 @@ func Concatenate(fnames []string) (fname2 string, err error) {
 		fname2,
 	)
 	logger.Debug(cmd)
-	_, err = exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
 	if err != nil {
+		logger.Errorf("ffmpeg: %s", out)
 		return
 	} else {
 		os.Remove(f.Name())
@@ -85,8 +86,9 @@ func ToMono(fname string) (fname2 string, err error) {
 		fname2,
 	)
 	logger.Debug(cmd)
-	_, err = exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
 	if err != nil {
+		logger.Errorf("ffmpeg: %s", out)
 		return
 	}
 	return
@@ -112,6 +114,7 @@ func Normalize(fname string, fnameout string) (err error) {
 	logger.Debug(cmd)
 	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
 	if err != nil {
+		logger.Errorf("ffmpeg: %s", out)
 		return
 	}
 	logger.Tracef("ffmpeg output: %s", out)

--- a/src/op1/drum.go
+++ b/src/op1/drum.go
@@ -56,9 +56,9 @@ func (drumpatch *DrumPatch) Save(audioClip string, fnameOut string) (err error) 
 		return
 	}
 	// generate a merged audio waveform, downsampled to 1 channel
-	cmd := fmt.Sprintf("-y -i %s -ss 0 -to 12 -ar 44100  -ac 1 %s", audioClip, fnameOut)
+	cmd := []string{"-y", "-i", audioClip, "-ss", "0", "-to", "12", "-ar", "44100", "-ac", "1", fnameOut}
 	logger.Debug(cmd)
-	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		logger.Errorf("ffmpeg: %s", out)
 		return

--- a/src/op1/synth.go
+++ b/src/op1/synth.go
@@ -384,9 +384,11 @@ func (s SynthPatch) SaveSample(fname string, fnameout string, trimSilence bool) 
 	// generate a truncated, merged audio waveform, downsampled to 1 channel
 	fnameDownsampled := fname + ".down.aif"
 	defer os.Remove(fnameDownsampled)
-	cmd := fmt.Sprintf("-y -i %s -ss %2.4f -to %2.4f -ar 44100  -ac 1 %s", fname, startClip, startClip+5.75, fnameDownsampled)
+	cmd := []string{"-y", "-i", fname, "-ss",
+		fmt.Sprintf("%2.4f", startClip), "-to", fmt.Sprintf("%2.4f", startClip+5.75),
+		"-ar", "44100", "-ac", "1", fnameDownsampled}
 	logger.Debug(cmd)
-	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	if err != nil {
 		logger.Errorf("ffmpeg: %s", out)
 		return

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -568,9 +568,9 @@ func makeSynthPatch(fname string, rootFrequency float64) (segments [][]models.Au
 	}
 
 	fnamewav := path.Join(basefolder, strings.Split(basefname, ".")[0]+".wav")
-	cmd := fmt.Sprintf("-y -i %s %s", fnameout, fnamewav)
+	cmd := []string{"-y", "-i", fnameout, fnamewav}
 	logger.Debug(cmd)
-	out, err := exec.Command("ffmpeg", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("ffmpeg", cmd...).CombinedOutput()
 	logger.Debugf("ffmpeg: %s", out)
 	if err != nil {
 		err = fmt.Errorf("ffmpeg; %s", err.Error())
@@ -578,11 +578,10 @@ func makeSynthPatch(fname string, rootFrequency float64) (segments [][]models.Au
 	}
 
 	waveformfname := fnamewav + ".png"
-	cmd = fmt.Sprintf("-i %s -o %s --background-color ffffff00 --waveform-color ffffff --amplitude-scale 2 --no-axis-labels --pixels-per-second 100 --height 160 --width %2.0f",
-		fnamewav, waveformfname, 5.75*100,
-	)
+	cmd = []string{"-i", fnamewav, "-o", waveformfname, "--background-color", "ffffff00", "--waveform-color", "ffffff", "--amplitude-scale", "2", "--no-axis-labels", "--pixels-per-second", "100", "--height", "160", "--width",
+		fmt.Sprintf("%2.0f", 5.75*100)}
 	logger.Debug(cmd)
-	out, err = exec.Command("audiowaveform", strings.Fields(cmd)...).CombinedOutput()
+	out, err = exec.Command("audiowaveform", cmd...).CombinedOutput()
 	if err != nil {
 		logger.Errorf("audiowaveform: %s", out)
 	}

--- a/src/waveform/waveform.go
+++ b/src/waveform/waveform.go
@@ -3,18 +3,16 @@ package waveform
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 
 	"github.com/schollz/logger"
 )
 
 // Image generates image of the waveform given a filename
 func Image(fnameIn, color string, length float64) (err error) {
-	cmd := fmt.Sprintf("-i %s -o %s.png --background-color ffffff00 --waveform-color %s --amplitude-scale 1 --no-axis-labels --pixels-per-second 100 --height 120 --width %2.0f",
-		fnameIn, fnameIn, color, length*100,
-	)
+	cmd := []string{"-i", fnameIn, "-o", fnameIn + ".png", "--background-color", "ffffff00", "--waveform-color", color, "--amplitude-scale", "1", "--no-axis-labels", "--pixels-per-second", "100", "--height", "120", "--width",
+		fmt.Sprintf("%2.0f", length*100)}
 	logger.Debug(cmd)
-	out, err := exec.Command("audiowaveform", strings.Fields(cmd)...).CombinedOutput()
+	out, err := exec.Command("audiowaveform", cmd...).CombinedOutput()
 	if err != nil {
 		logger.Errorf("audiowaveform: %s", out)
 	}


### PR DESCRIPTION
Hey! First off, just want to say thank you so much for creating this - it's pretty much essential for anybody who wants to make their own OP patches.

I was trying to make some OP-Z drum patches from a sample kit and I noticed that ffmpeg was erroring - it looks like the combination of `fmt.Sprintf` and `strings.Fields` is causing malformed ffmpeg commands when input files have spaces in their filenames.

For this PR, I replaced the `fmt.Sprintf` calls to use a slice of strings instead. For consistency, I did this for all the commands, not just ffmpeg - would love your feedback!

Example:

```
% go run . drum "BD dx200-909ishShortBeautyKick.wav" "BD dx200-909ishThumppppoKick.wav"
converted [BD dx200-909ishShortBeautyKick.wav BD dx200-909ishThumppppoKick.wav] -> BD dx200-909ishShortBeautyKick_patch.aif
```